### PR TITLE
Remove unneeded rule from the EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,3 @@ trim_trailing_whitespace = false
 [{Makefile,**.mk}]
 # Use tabs for indentation (Makefiles require tabs)
 indent_style = tab
-[*.scss]
-indent_size = 2
-indent_style = space


### PR DESCRIPTION
Already got line 5 and 6:

<img width="368" alt="Screen Shot 2020-12-31 at 3 18 27 pm" src="https://user-images.githubusercontent.com/418747/103395953-60faa900-4b7c-11eb-8a07-ed5eb04fa9ee.png">
